### PR TITLE
Add :first/:last to #find

### DIFF
--- a/lib/couchrest/model/class_proxy.rb
+++ b/lib/couchrest/model/class_proxy.rb
@@ -92,6 +92,8 @@ module CouchRest
             first
           elsif id == :last
             last
+          elsif id == :all
+            all
           else
             get(id)
           end

--- a/lib/couchrest/model/class_proxy.rb
+++ b/lib/couchrest/model/class_proxy.rb
@@ -90,7 +90,7 @@ module CouchRest
         def find(id)
           if id == :first
             first
-          if id == :last
+          elsif id == :last
             last
           else
             get(id)

--- a/lib/couchrest/model/class_proxy.rb
+++ b/lib/couchrest/model/class_proxy.rb
@@ -86,7 +86,14 @@ module CouchRest
           doc.database = @database if doc && doc.respond_to?(:database)
           doc
         end
-        alias :find :get
+
+        def find(id)
+          if id == :first
+            first
+          else
+            get(id)
+          end
+        end
 
         def get!(id)
           doc = @klass.get!(id, @database)

--- a/lib/couchrest/model/class_proxy.rb
+++ b/lib/couchrest/model/class_proxy.rb
@@ -90,6 +90,8 @@ module CouchRest
         def find(id)
           if id == :first
             first
+          if id == :last
+            last
           else
             get(id)
           end

--- a/lib/couchrest/model/document_queries.rb
+++ b/lib/couchrest/model/document_queries.rb
@@ -69,7 +69,27 @@ module CouchRest
             nil
           end
         end
-        alias :find :get
+
+        # Find a document from the database by id or special command
+        # No exceptions will be raised if the document isn't found
+        #
+        # ==== Returns
+        # Object:: if the document was found
+        # or
+        # Nil::
+        # 
+        # === Parameters
+        # id<String, Integer>:: Document ID or special command [:first]
+        # db<Database>:: optional option to pass a custom database to use
+        def find(id)
+          if id == :first
+            first
+          elsif id == :last
+            last
+          else
+            get(id)
+          end
+        end
 
         # Load a document from the database by id
         # An exception will be raised if the document isn't found

--- a/lib/couchrest/model/document_queries.rb
+++ b/lib/couchrest/model/document_queries.rb
@@ -86,6 +86,8 @@ module CouchRest
             first
           elsif id == :last
             last
+          elsif id == :all
+            all
           else
             get(id)
           end


### PR DESCRIPTION
Get's us compatible with shoulda matchers. Missing the :all option to be API compatible with http://apidock.com/rails/ActiveRecord/Base/find/class but I'm not too worried about it.
