### PR TITLE
Prevent dates from being stored/retrieved incorrectly

### DIFF
--- a/lib/couchrest/model/core_extensions/time_parsing.rb
+++ b/lib/couchrest/model/core_extensions/time_parsing.rb
@@ -29,26 +29,26 @@ module CouchRest
         # Attemtps to parse a time string in ISO8601 format.
         # If no match is found, the standard time parse will be used.
         #
-        # Times, unless provided with a time zone, are assumed to be in 
+        # Times, unless provided with a time zone, are assumed to be in
         # UTC.
         #
         def parse_iso8601(string)
-          if (string =~ /(\d{4})[\-|\/](\d{2})[\-|\/](\d{2})[T|\s](\d{2}):(\d{2}):(\d{2})(Z| ?([\+|\s|\-])?(\d{2}):?(\d{2}))?/)
+          if (string =~ /(\d{4})[\-|\/](\d{2})[\-|\/](\d{2})[T|\s](\d{2}):(\d{2}):(\d{2}(\.\d+)?)(Z| ?([\+|\s|\-])?(\d{2}):?(\d{2}))?/)
             # $1 = year
             # $2 = month
             # $3 = day
             # $4 = hours
             # $5 = minutes
-            # $6 = seconds
-            # $7 = UTC or Timezone
-            # $8 = time zone direction
-            # $9 = tz difference hours
-            # $10 = tz difference minutes
+            # $6 = seconds (with $7 for fraction)
+            # $8 = UTC or Timezone
+            # $9 = time zone direction
+            # $10 = tz difference hours
+            # $11 = tz difference minutes
 
-            if (!$7.to_s.empty? && $7 != 'Z')
-              new($1.to_i, $2.to_i, $3.to_i, $4.to_i, $5.to_i, $6.to_i, "#{$8 == '-' ? '-' : '+'}#{$9}:#{$10}")
+            if $8 == 'Z' || $8.to_s.empty?
+              utc($1.to_i, $2.to_i, $3.to_i, $4.to_i, $5.to_i, $6.to_r)
             else
-              utc($1.to_i, $2.to_i, $3.to_i, $4.to_i, $5.to_i, $6.to_i)
+              new($1.to_i, $2.to_i, $3.to_i, $4.to_i, $5.to_i, $6.to_r, "#{$9 == '-' ? '-' : '+'}#{$10}:#{$11}")
             end
           else
             parse(string)


### PR DESCRIPTION
Updates `parse_iso8601` to the latest version from couchrest_model. Times weren’t getting parsed correctly, causing them to change during storage and retrieval based on the user’s timezone’s offset from UTC.